### PR TITLE
Toasts as progress indicators

### DIFF
--- a/src/pyqttoast/toast.py
+++ b/src/pyqttoast/toast.py
@@ -338,6 +338,15 @@ class Toast(QDialog):
                                      * self.__duration_bar_container.width())
         self.__duration_bar_chunk.setFixedWidth(new_chunk_width)
 
+    def __set_duration_bar(self, fraction):
+        """Set the width of the duration bar chunk with the specified fraction"""
+
+        if self.__duration_bar_timer.isActive():
+            self.__duration_bar_timer.stop()
+
+        new_chunk_width = math.floor(fraction * self.__duration_bar_container.width())
+        self.__duration_bar_chunk.setFixedWidth(new_chunk_width)
+
     def __update_position_xy(self, animate: bool = True):
         """Update the x and y position of the toast with an optional animation
 
@@ -1419,6 +1428,13 @@ class Toast(QDialog):
         if self.__used:
             return
         self.__duration_bar_color = color
+
+    def setDurationBarValue(self, fraction: float):
+        """Set the width of the duration bar with the specified fraction
+
+        :param fraction: The fraction of the total width from 0.0 to 1.0
+        """
+        self.__set_duration_bar(fraction)
 
     def getTitleFont(self) -> QFont:
         """Get the font of the title

--- a/src/pyqttoast/toast.py
+++ b/src/pyqttoast/toast.py
@@ -283,6 +283,8 @@ class Toast(QDialog):
     def hide(self):
         """Start hiding process of the toast notification"""
 
+        self.__used = True
+
         if not self.__fading_out:
             self.__fading_out = True
             if self.__duration != 0:

--- a/src/pyqttoast/toast.py
+++ b/src/pyqttoast/toast.py
@@ -311,9 +311,6 @@ class Toast(QDialog):
             self.__elapsed_time = 0
             self.__fading_out = False
 
-            # Emit signal
-            self.closed.emit()
-
             # Update every other currently shown notification
             for toast in Toast.__currently_shown:
                 toast.__update_position_y()
@@ -323,6 +320,9 @@ class Toast(QDialog):
             timer.setSingleShot(True)
             timer.timeout.connect(Toast.__show_next_in_queue)
             timer.start(self.__fade_in_duration)
+
+        # Emit signal
+        self.closed.emit()
 
     def __update_duration_bar(self):
         """Update the duration bar chunk with the elapsed time"""


### PR DESCRIPTION
Nice library, though I'm trying to use your Toasts to display asynchronous progress (rather than time) and ran into a couple of issues.

The first two patches address some race conditions around Toasts being shown after already being hidden.

The last patch is just a much cleaner way to manually set the width of the duration bar proportional to current progress.

There's a whole bunch of considerations around updating these from other threads, but that's outside the scope of this library.